### PR TITLE
Use useBytes = TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # vdiffr 0.3.0.9000
 
+- Fix warnings in non-UTF-8 MBCS locale (#59, @yutannihilation).
+
 
 # vdiffr 0.3.0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -28,7 +28,7 @@ capitalise <- function(x) {
 }
 
 read_file <- function(file) {
-  readChar(file, file.info(file)$size)
+  readChar(file, file.info(file)$size, useBytes = TRUE)
 }
 
 package_version <- function(pkg) {


### PR DESCRIPTION
On my locale, `readChar()` complains everytime when it's called (I guess this won't happen on non-UTF-8 MBCS locale).

![image](https://user-images.githubusercontent.com/1978793/50938966-2d6d7280-14be-11e9-9976-eccad9839734.png)

I guess `useBytes = TRUE` is correct for all cases since `file.info()` is the byte size, not character length.

(I will send the same PR for fontquiver)