### PR TITLE
Insert newlines after getOption("width") is reached in `manage_cases()`

### DIFF
--- a/R/testthat-reporter.R
+++ b/R/testthat-reporter.R
@@ -72,6 +72,11 @@ vdiffrReporter <-
 
       add_result = function(context, test, result) {
         cat(single_letter_summary(result))
+        private$.result_counter <- private$.result_counter + 1
+        if (private$.result_counter >= getOption("width")) {
+          cat("\n")
+          private$.result_counter <- 0
+        }
 
         case <- attr(result, "vdiffr_case")
         if (expectation_error(result)) {
@@ -92,6 +97,10 @@ vdiffrReporter <-
           ))
         }
       }
+    ),
+    
+    private = list(
+      .result_counter = 0
     )
   )
 


### PR DESCRIPTION
This is a PR for #66 which seems to solve the issue.
Couple of notes:
- I didn't really know how and where to add tests for this. And even if this sort of thing should be tested.
- While running `devtools::test()` on current commit (4561787efdb7fe6f2c3d0f6ff4f751d148dcecf3) I got updated 'tests/mock.Rout.fail' file. It seems to change the same after this PR's change is done.