### PR TITLE
add a pkgdown website

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,6 @@
 ^revdep
 ^vdiffr.Rproj$
 ^CRAN-RELEASE$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ revdep/checks
 revdep/library
 src-i386/
 src-x64/
+docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
 
-language: r
-sudo: false
+language: R
 cache: packages
 
 matrix:
   include:
-    - r: oldrel
-    - r: release
-      env: R_CODECOV=true
-    - r: devel
-    - os: osx
-      osx_image: xcode7.2
-      latex: false
-
-after_success:
-  - if [[ "${R_CODECOV}" ]]; then R -e 'covr::codecov()'; fi
+  - r: devel
+  - r: release
+    after_success:
+    - Rscript -e 'covr::codecov()'
+    before_cache:
+    - Rscript -e 'remotes::install_cran("pkgdown")'
+    deploy:
+      provider: script
+      script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
+      skip_cleanup: true
+  - r: oldrel
+  - r: 3.4
+  - r: 3.3
+  - r: 3.2
+  - os: osx
+    osx_image: xcode7.2
+    latex: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 
 # vdiffr
 
+[![CRAN status](https://www.r-pkg.org/badges/version/vdiffr)](https://cran.r-project.org/package=vdiffr)
 [![Travis Build Status](https://travis-ci.org/r-lib/vdiffr.svg?branch=master)](https://travis-ci.org/r-lib/vdiffr)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/r-lib/vdiffr?branch=master&svg=true)](https://ci.appveyor.com/project/r-lib/vdiffr)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 
 # vdiffr
 
-[![CRAN status](https://www.r-pkg.org/badges/version/vdiffr)](https://cran.r-project.org/package=vdiffr)
+<!-- badges: start -->
 [![Travis Build Status](https://travis-ci.org/r-lib/vdiffr.svg?branch=master)](https://travis-ci.org/r-lib/vdiffr)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/github/r-lib/vdiffr?branch=master&svg=true)](https://ci.appveyor.com/project/r-lib/vdiffr)
+[![Codecov test coverage](https://codecov.io/gh/r-lib/vdiffr/branch/master/graph/badge.svg)](https://codecov.io/gh/r-lib/vdiffr?branch=master)
+[![CRAN status](https://www.r-pkg.org/badges/version/vdiffr)](https://cran.r-project.org/package=vdiffr)
+<!-- badges: end -->
 
 vdiffr is an extension to the package testthat that makes it easy to
 test for visual regressions. It provides a Shiny app to manage failed

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,16 @@
+destination: docs
+
+navbar:
+  structure:
+    left:  [home, reference, news]
+    right: [github]
+  components:
+    news:
+      text: News
+      menu:
+      - text: "Release notes"
+      - text: "Version 0.3.0"
+        href: https://www.tidyverse.org/articles/2019/01/vdiffr-0-3-0/
+      - text: "------------------"
+      - text: "Change log"
+        href: news/index.html

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+url: https://vdiffr.r-lib.org
 destination: docs
 
 navbar:


### PR DESCRIPTION
This closes #69 

This is for now a basic website. 
* It seems there is no template in the r-lib universe. 
* The package has no vignettes, so no articles.

I added a link to v0.3.0 release note and a CRAN badge for the README. 

There still some things to do but I don't know if it should be in this PR or after

- [x] Add travis deployment. I know what lines to add but don't want to mess with your process. 
- [x] Add a url to pkgdown website. https://vdiffr.r-lib.org I guess. Don't know the process for that
- [x] Add a covr badge. Coverage seems to happen according to `.travis.yml` but can't find the repo on codecov

Also, as there is a few functions I did not organize them in the reference. Do you think we should regroup as some other pkgdown website ?

Happy to continue based on your input. 

