### PR TITLE
Add libpng to SystemRequirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,4 +43,4 @@ RoxygenNote: 7.1.1.9001
 Roxygen: list(markdown = TRUE)
 URL: https://vdiffr.r-lib.org/, https://github.com/r-lib/vdiffr
 BugReports: https://github.com/r-lib/vdiffr/issues
-SystemRequirements: C++11
+SystemRequirements: C++11, libpng


### PR DESCRIPTION
Adds `libpng` to the `SystemRequirements` field.

Closes #111