### PR TITLE
Change name of graphic device to differentiate it from svglite

### DIFF
--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -904,7 +904,7 @@ void makeDevice(SvgStreamPtr stream, std::string bg_, double width, double heigh
       cpp11::stop("Failed to start SVG device");
 
     pGEDevDesc dd = GEcreateDevDesc(dev);
-    GEaddDevice2(dd, "devSVG");
+    GEaddDevice2(dd, "devSVG_vdiffr");
     GEinitDisplayList(dd);
 
   } END_SUSPEND_INTERRUPTS;


### PR DESCRIPTION
Fix #135 

This is a small change to make sure the differ device doesn't share the same name as svglite, seeing how the two might branch in functionality