### PR TITLE
Improve error message when title arg is missing (Fixes #149)

### DIFF
--- a/R/expect-doppelganger.R
+++ b/R/expect-doppelganger.R
@@ -102,7 +102,7 @@ expect_doppelganger <- function(title,
   testthat::local_edition(3)
 
   if (!is_string(title)) {
-    abort("title argument must be a string")
+    abort("`title` must be a string")
   }
   
   fig_name <- str_standardise(title)

--- a/R/expect-doppelganger.R
+++ b/R/expect-doppelganger.R
@@ -101,6 +101,10 @@ expect_doppelganger <- function(title,
                                 variant = NULL) {
   testthat::local_edition(3)
 
+  if (!is_string(title)) {
+    abort("title argument must be a string")
+  }
+  
   fig_name <- str_standardise(title)
   file <- paste0(fig_name, ".svg")
 


### PR DESCRIPTION
Just a straightforward argument check -- let me know if you'd like me to take a different approach (e.g. `stopifnot`) or add a test for this (for now I just kept it simple)