### PR TITLE
Remove C++11

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,1 @@
-CXX_STD = CXX11
-
 PKG_LIBS = -lpng -lz

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,3 @@
-CXX_STD = CXX11
-
 VERSION = 2.7.4
 RWINLIB = ../windows/harfbuzz-${VERSION}
 


### PR DESCRIPTION
From https://github.com/r-lib/svglite/commit/ecc295e13933fc41804815ee149c08daf38a822c

For

```
checking C++ specification ... NOTE
  Obsolete C++11 standard request will be ignored
```

and

```
Result: NOTE 
    Specified C++11: please drop specification unless essential
```